### PR TITLE
build: update broken dependency url

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -3000,7 +3000,7 @@ roots = []
 
 [[grammar]]
 name = "gemini"
-source = { git = "https://git.sr.ht/~sfr/tree-sitter-gemini", rev = "3cc5e4bdf572d5df4277fc2e54d6299bd59a54b3" }
+source = { git = "https://git.sr.ht/~nbsp/tree-sitter-gemini", rev = "3cc5e4bdf572d5df4277fc2e54d6299bd59a54b3" }
 
 [[language]]
 name = "templ"


### PR DESCRIPTION
This fixes issue when building with cargo and also fixes building with nix.

The origin for origintree-sitter-gemini no longer exists this fix points to a fork using the same SHA
