### PR TITLE
Update languages.toml to fix broken URL that causes AUR build to fail

### DIFF
--- a/languages.toml
+++ b/languages.toml
@@ -1,5 +1,6 @@
 # Language support configuration.
 # See the languages documentation: https://docs.helix-editor.com/master/languages.html
+use-grammars = { except = [ "hare", "wren", "gemini", "lean" ] }
 
 [language-server]
 


### PR DESCRIPTION
also I'm wondering if conflicts=('helix') in the PKGBUILD is necessary since the binary is renamed and the PKG dir is different?

https://github.com/helix-editor/helix/pull/9316/files ganked from here